### PR TITLE
Use startActivityForResult() when launching OpenVPN for Android

### DIFF
--- a/app/src/main/java/biz/incomsystems/fwknop2/SendSPA.java
+++ b/app/src/main/java/biz/incomsystems/fwknop2/SendSPA.java
@@ -595,7 +595,8 @@ public class SendSPA implements OnSessionStartedListener, OnSessionFinishedListe
 
 
                     try {
-                        mActivity.startActivity(i);
+                        // by using the "ForResult" variant, de.blinkt.openvpn can call getCallingPackage() and properly whitelist us
+                        mActivity.startActivityForResult(i, 1);
                     } catch (Exception ex) {
                         AlertDialog alertDialog = new AlertDialog.Builder(mActivity).create();
                         alertDialog.setTitle("Error");


### PR DESCRIPTION
The previous use of startActivity() didn't allow OpenVPN for Android to
see which application attempted to start a profile, causing the
whitelist to not work properly. By using startActivityForResult(),
OpenVPN for Android is able to find the caller via getCallingPackage()
and whitelist Fwknop2 so that it can in the future automatically connect
to a VPN profile after sending the SPA.

Tested on LineageOS 15.1 (Android 8.1).

Signed-off-by: Matt Merhar <mattmerhar@protonmail.com>